### PR TITLE
fix: update careers page link in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -42,4 +42,4 @@ Some of the more useful resources have been compiled below. Browse away 📜
 - [Bug Bounty](https://lido.fi/bug-bounty)
 - [Discord](https://discord.com/invite/lido)
 
-Lastly - if you’re looking to join the team of Lido contributors, check out the [opportunities](https://careers.lido.fi/) page!
+Lastly - if you’re looking to join the team of Lido contributors, check out the [opportunities](https://opportunities.lido.fi/) page!


### PR DESCRIPTION
- Updated the link to the opportunities page from `https://careers.lido.fi/` to `https://opportunities.lido.fi/` in `profile/README.md`.